### PR TITLE
package: AIモデルの切り替え

### DIFF
--- a/app/Http/Controllers/AiController.php
+++ b/app/Http/Controllers/AiController.php
@@ -12,7 +12,7 @@ class AiController extends Controller
         $user_input = $request->input('prompt');
 
         $response = OpenAI::chat()->create([
-            'model' => 'gpt-3.5-turbo',
+            'model' => 'gpt-4o-mini',
             'messages' => [
                 ['role' => 'system', 'content' => 'あなたは親切なアシスタントです。'],
                 ['role' => 'user', 'content' => $user_input],

--- a/resources/js/Pages/Main/Hooks/useHomeContextValue.js
+++ b/resources/js/Pages/Main/Hooks/useHomeContextValue.js
@@ -263,6 +263,8 @@ const useHomeContextValue = (notepads, modifierPrompts, changePrompts) => {
                 "【メモ本文】\n" +
                 getShowingPage().written_content;
 
+            console.log("プロンプト:", prompt);
+
             const aiResponse = await axios.post("/api/ai/generate", { prompt });
 
             const new_changed_content = aiResponse.data.result;


### PR DESCRIPTION
OpenAI APIのモデルを
`gpt-3.5-turbo`から`gpt-4o-mini`に切り替え
こっちのほうが性能・コスト・速度で勝るらしい
そもそも3.5 turboはレガシーモデルっぽいので、もう使う意味がねえ...